### PR TITLE
Support NDK 17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ android {
             }
         }
         ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'mips', 'mips64'
+            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
     }
     buildTypes {


### PR DESCRIPTION
'armeabi', 'mips' and 'mips64' are no longer supported by Android NDK, so to be able to compile the project one has to manually remove those targets.