### PR TITLE
Add crypto_scalarmult_base

### DIFF
--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -266,6 +266,15 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1seal_1open(
   return (jint) result;
 }
 
+JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1scalarmult_1base(JNIEnv *jenv, jclass jcls, jbyteArray j_pk, jbyteArray j_sk) {
+  unsigned char *pk = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_pk, 0);
+  unsigned char *sk = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_sk, 0);
+  int result = (int)crypto_scalarmult_base(pk, sk);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_pk, (jbyte *) pk, 0);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_sk, (jbyte *) sk, 0);
+  return (jint)result;
+}
+
 /* *****************************************************************************
  * Public-key cryptography - signatures
  * *****************************************************************************

--- a/android/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/android/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -38,6 +38,8 @@ public class SodiumJNI {
   public final static native int crypto_box_seal(byte[] c, byte[] m, long mlen, byte[] pk);
   public final static native int crypto_box_seal_open(byte[] m, byte[] c, long clen, byte[] pk, byte[] sk);
 
+  public final static native int crypto_scalarmult_base(byte[] pk, final byte[] sk);
+
   public final static native int crypto_sign_publickeybytes();
   public final static native int crypto_sign_secretkeybytes();
   public final static native int crypto_sign_seedbytes();

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -403,6 +403,26 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void crypto_scalarmult_base(final String sk, final Promise p) {
+    try {
+      byte[] skb = Base64.decode(sk, Base64.NO_WRAP);
+      if (skb.length != Sodium.crypto_box_secretkeybytes())
+        p.reject(ESODIUM,ERR_BAD_KEY);
+      else {
+        byte[] pkb = new byte[Sodium.crypto_box_publickeybytes()];
+        int result = Sodium.crypto_scalarmult_base(pkb, skb);
+        if (result != 0)
+          p.reject(ESODIUM,ERR_BAD_KEY);
+        else
+          p.resolve(Base64.encodeToString(pkb,Base64.NO_WRAP));
+      }
+    }
+    catch (Throwable t) {
+      p.reject(ESODIUM,ERR_FAILURE,t);
+    }
+  }
+
   // ***************************************************************************
   // * Public-key cryptography - signatures
   // ***************************************************************************

--- a/ios/RCTSodium/RCTSodium.h
+++ b/ios/RCTSodium/RCTSodium.h
@@ -31,6 +31,8 @@
 - (void) crypto_box_open_easy:(NSString*)c n:(NSString*)n pk:(NSString*)pk sk:(NSString*)sk resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_box_open_easy_afternm:(NSString*)c n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
+- (void) crypto_scalarmult_base:(NSString*)sk resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+
 - (void) crypto_sign_keypair: resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_sign_ed25519_sk_to_pk:(NSString*)sk resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 

--- a/ios/RCTSodium/RCTSodium.m
+++ b/ios/RCTSodium/RCTSodium.m
@@ -314,6 +314,18 @@ RCT_EXPORT_METHOD(crypto_box_seal_open:(NSString*)c pk:(NSString*)pk sk:(NSStrin
     resolve([[NSData dataWithBytesNoCopy:dm length:cipher_len freeWhenDone:NO] base64EncodedStringWithOptions:0]);
 }
 
+RCT_EXPORT_METHOD(crypto_scalarmult_base:(NSString*)sk resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+  const NSData *dsk = [[NSData alloc] initWithBase64EncodedString:sk options:0];
+  unsigned char pk[crypto_box_PUBLICKEYBYTES];
+  if (!dsk) reject(ESODIUM,ERR_FAILURE, nil);
+  else if (dsk.length != crypto_box_SECRETKEYBYTES) reject(ESODIUM, ERR_BAD_KEY, nil);
+  else if (crypto_scalarmult_base(pk, [dsk bytes]) != 0)
+    reject(ESODIUM,ERR_FAILURE, nil);
+  else
+    resolve([[NSData dataWithBytesNoCopy:pk length:sizeof(pk) freeWhenDone:NO]  base64EncodedStringWithOptions:0]);
+}
+
 // *****************************************************************************
 // * Public-key cryptography - signatures
 // *****************************************************************************


### PR DESCRIPTION
Implements `crypto_scalarmult_base` which can be used to compute the public key given a secret key previously generated with `crypto_box_keypair()`.

Reference: https://libsodium.gitbook.io/doc/public-key_cryptography/authenticated_encryption#key-pair-generation