### PR TITLE
Added .podspec file to allow use with CocoaPods in React Native >0.60

### DIFF
--- a/react-native-sodium.podspec
+++ b/react-native-sodium.podspec
@@ -1,0 +1,22 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/lyubo/react-native-sodium.git", :tag => "v#{s.version}" }
+  s.source_files  = ["ios/**/*.{h,m}","libsodium/libsodium-ios/**/*.{h,m}"]
+
+  s.vendored_libraries = 'libsodium/libsodium-ios/lib/libsodium.a'
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/Headers/Public/#{s.name}/**'}
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
This PR aims to add a valid podspec file to the package that supports use with CocoaPods and RN > 0.60.