### PR TITLE
Implement crypto_secretbox_keygen and types

### DIFF
--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -73,11 +73,10 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1macby
 return (jint) crypto_secretbox_MACBYTES;
 }
 
-JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
+JNIEXPORT void JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
   unsigned char *key = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_key, 0);
-  int result = (int)crypto_secretbox_keygen(key);
+  crypto_secretbox_keygen(key);
   (*jenv)->ReleaseByteArrayElements(jenv, j_key, (jbyte *) key, 0);
-  return (jint)result;
 }
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1easy(JNIEnv *jenv, jclass jcls, jbyteArray j_c, jbyteArray j_m, jlong j_mlen, jbyteArray j_n, jbyteArray j_k) {

--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -73,6 +73,13 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1macby
 return (jint) crypto_secretbox_MACBYTES;
 }
 
+JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
+  unsigned char *key = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_key, 0);
+  int result = (int)crypto_secretbox_keygen(key);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_key, (jbyte *) key, 0);
+  return (jint)result;
+}
+
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1easy(JNIEnv *jenv, jclass jcls, jbyteArray j_c, jbyteArray j_m, jlong j_mlen, jbyteArray j_n, jbyteArray j_k) {
   unsigned char *c = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_c, 0);
   unsigned char *m = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_m, 0);

--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -117,6 +117,12 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1keybytes(J
   return (jint) crypto_auth_KEYBYTES;
 }
 
+JNIEXPORT void JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
+  unsigned char *key = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_key, 0);
+  crypto_auth_keygen(key);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_key, (jbyte *) key, 0);
+}
+
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth(JNIEnv *jenv, jclass jcls, jbyteArray j_out, jbyteArray j_in, jlong j_inlen, jbyteArray j_k) {
   unsigned char *out = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_out, 0);
   unsigned char *in = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_in, 0);

--- a/android/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/android/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -13,7 +13,7 @@ public class SodiumJNI {
   public final static native int crypto_secretbox_keybytes();
   public final static native int crypto_secretbox_noncebytes();
   public final static native int crypto_secretbox_macbytes();
-  public final static native int crypto_secretbox_keygen(byte[] key);
+  public final static native void crypto_secretbox_keygen(byte[] key);
   public final static native int crypto_secretbox_easy(byte[] c, final byte[] m, final long mlen, final byte[] n, final byte[] k);
   public final static native int crypto_secretbox_open_easy(byte[] m, final byte[] c, final long clen,  final byte[] n, final byte[] k);
 

--- a/android/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/android/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -19,6 +19,7 @@ public class SodiumJNI {
 
   public final static native int crypto_auth_keybytes();
   public final static native int crypto_auth_bytes();
+  public final static native void crypto_auth_keygen(byte[] key);
   public final static native int crypto_auth(byte[] out, final byte[] in, final long inlen,  final byte[] k);
   public final static native int crypto_auth_verify(final byte[] h, final byte[] in, final long inlen, final byte[] k);
 

--- a/android/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/android/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -13,6 +13,7 @@ public class SodiumJNI {
   public final static native int crypto_secretbox_keybytes();
   public final static native int crypto_secretbox_noncebytes();
   public final static native int crypto_secretbox_macbytes();
+  public final static native int crypto_secretbox_keygen(byte[] key);
   public final static native int crypto_secretbox_easy(byte[] c, final byte[] m, final long mlen, final byte[] n, final byte[] k);
   public final static native int crypto_secretbox_open_easy(byte[] m, final byte[] c, final long clen,  final byte[] n, final byte[] k);
 

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -129,9 +129,7 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
       byte[] key = new byte[Sodium.crypto_secretbox_keybytes()];
       Sodium.crypto_secretbox_keygen(key);
       
-      WritableNativeMap result = new WritableNativeMap();
-      result.putString("key",Base64.encodeToString(key,Base64.NO_WRAP));
-      p.resolve(result);
+      p.resolve(Base64.encodeToString(key,Base64.NO_WRAP));
     }
     catch (Throwable t) {
       p.reject(ESODIUM,ERR_FAILURE,t);
@@ -170,12 +168,12 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
       byte[] kb = Base64.decode(k, Base64.NO_WRAP);
       if (kb.length != Sodium.crypto_secretbox_keybytes())
         p.reject(ESODIUM,ERR_BAD_KEY);
-      else if (nb.length != Sodium.crypto_box_noncebytes())
+      else if (nb.length != Sodium.crypto_secretbox_noncebytes())
         p.reject(ESODIUM,ERR_BAD_NONCE);
-      else if (cb.length <=  Sodium.crypto_box_macbytes())
+      else if (cb.length <=  Sodium.crypto_secretbox_macbytes())
         p.reject(ESODIUM,ERR_BAD_MSG);
       else {
-        byte[] mb = new byte[cb.length - Sodium.crypto_box_macbytes()];
+        byte[] mb = new byte[cb.length - Sodium.crypto_secretbox_macbytes()];
         int result = Sodium.crypto_secretbox_open_easy(mb, cb, cb.length, nb, kb);
         if (result != 0)
           p.reject(ESODIUM,ERR_FAILURE);

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -127,14 +127,11 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
   public void crypto_secretbox_keygen(final Promise p){
     try {
       byte[] key = new byte[Sodium.crypto_secretbox_keybytes()];
-
-      if (Sodium.crypto_secretbox_keygen(key) != 0)
-        p.reject(ESODIUM,ERR_FAILURE);
-      else {
-        WritableNativeMap result = new WritableNativeMap();
-        result.putString("key",Base64.encodeToString(key,Base64.NO_WRAP));
-        p.resolve(result);
-      }
+      Sodium.crypto_secretbox_keygen(key);
+      
+      WritableNativeMap result = new WritableNativeMap();
+      result.putString("key",Base64.encodeToString(key,Base64.NO_WRAP));
+      p.resolve(result);
     }
     catch (Throwable t) {
       p.reject(ESODIUM,ERR_FAILURE,t);

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -190,6 +190,19 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
   // * Secret-key cryptography - authentication
   // ***************************************************************************
   @ReactMethod
+  public void crypto_auth_keygen(final Promise p){
+    try {
+      byte[] key = new byte[Sodium.crypto_auth_keybytes()];
+      Sodium.crypto_auth_keygen(key);
+      
+      p.resolve(Base64.encodeToString(key,Base64.NO_WRAP));
+    }
+    catch (Throwable t) {
+      p.reject(ESODIUM,ERR_FAILURE,t);
+    }
+  }
+
+  @ReactMethod
   public void crypto_auth(String in, String k, final Promise p){
     try {
       byte[] out = new byte[Sodium.crypto_auth_bytes()];

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -124,6 +124,24 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
   // * Secret-key cryptography - authenticated encryption
   // ***************************************************************************
   @ReactMethod
+  public void crypto_secretbox_keygen(final Promise p){
+    try {
+      byte[] key = new byte[Sodium.crypto_secretbox_keybytes()];
+
+      if (Sodium.crypto_secretbox_keygen(key) != 0)
+        p.reject(ESODIUM,ERR_FAILURE);
+      else {
+        WritableNativeMap result = new WritableNativeMap();
+        result.putString("key",Base64.encodeToString(key,Base64.NO_WRAP));
+        p.resolve(result);
+      }
+    }
+    catch (Throwable t) {
+      p.reject(ESODIUM,ERR_FAILURE,t);
+    }
+  }
+
+  @ReactMethod
   public void crypto_secretbox_easy(final String m, final String n, final String k, final Promise p) {
     try {
       byte[] mb = Base64.decode(m, Base64.NO_WRAP);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,362 @@
+declare module "react-native-sodium" {
+  export function sodium_version_string(): Promise<any>;
+
+  //
+  // Generating random data
+  //
+  /**
+   * Returns an unpredictable value between 0 and 0xffffffff (included).
+   */
+  export function randombytes_random(): Promise<any>;
+
+  /**
+   * Returns an unpredictable value between 0 and upper_bound (excluded).
+   * Unlike randombytes_random() % upper_bound, it guarantees a uniform distribution of
+   * the possible output values even when upper_bound is not a power of 2. Note that an
+   * upper_bound < 2 leaves only a single element to be chosen, namely 0.
+   */
+  export function randombytes_uniform(upper_bound: number): Promise<any>;
+
+  /**
+   * Create a nonce
+   */
+  export function randombytes_buf(size: number): Promise<any>;
+
+  /**
+   * This deallocates the global resources used by the pseudo-random number generator.
+   * More specifically, when the /dev/urandom device is used, it closes the descriptor.
+   * Explicitly calling this function is almost never required.
+   */
+  export function randombytes_close(): Promise<any>;
+
+  /**
+   * Reseeds the pseudo-random number generator, if it supports this operation.
+   * Calling this function is not required with the default generator, even after a fork() call,
+   * unless the descriptor for /dev/urandom was closed using randombytes_close().
+   */
+  export function randombytes_stir(): Promise<any>;
+
+  //
+  // Secret-key cryptography - Authenticated encryption
+  //
+  /**
+   * Bytes of key on secret-key cryptography, authenticated encryption
+   */
+  export const crypto_secretbox_KEYBYTES: any;
+
+  /**
+   * Bytes of nonce on secret-key cryptography, authenticated encryption
+   */
+  export const crypto_secretbox_NONCEBYTES: any;
+
+  /**
+   * Bytes of the authentication on secret-key cryptography, authenticated encryption
+   */
+  export const crypto_secretbox_MACBYTES: any;
+
+  /**
+   * Creates a random key. It is equivalent to calling randombytes_buf() but improves code
+   * clarity and can prevent misuse by ensuring that the provided key length is always be correct.
+   */
+  export function crypto_secretbox_keygen(): Promise<any>;
+
+  /**
+   * Encrypts a message, with a nonce and a key.
+   */
+  export function crypto_secretbox_easy(
+    message: string,
+    nonce: string,
+    key: string
+  ): Promise<any>;
+
+  /**
+   * Verifies and decrypts a ciphertext produced by crypto_secretbox_easy().
+   * The nonce and the key have to match the used to encrypt and authenticate the message.
+   */
+  export function crypto_secretbox_open_easy(
+    cipher: string,
+    nonce: string,
+    key: string
+  ): Promise<any>;
+
+  //
+  // Secret-key cryptography - Authentication
+  //
+  /**
+   * Bytes of key on secret-key cryptography, authentication
+   */
+  export const crypto_auth_KEYBYTES: any;
+
+  /**
+   * Bytes of the authentication on secret-key cryptography, authentication
+   */
+  export const crypto_auth_BYTES: any;
+
+  /**
+   * Computes a tag for the message and the key.
+   */
+  export function crypto_auth(inTag: string, key: string): Promise<any>;
+
+  /**
+   * Verifies that the tag stored at h is a valid tag for the message, and the key.
+   */
+  export function crypto_auth_verify(
+    h: string,
+    inTag: string,
+    key: string
+  ): Promise<any>;
+
+  //
+  // Public-key cryptography - Authenticated encryption
+  //
+  /**
+   * Bytes of public key on public-key cryptography, authenticated encryption
+   */
+  export const crypto_box_PUBLICKEYBYTES: any;
+
+  /**
+   * Bytes of secret key on public-key cryptography, authenticated encryption
+   */
+  export const crypto_box_SECRETKEYBYTES: any;
+
+  /**
+   * Bytes of nonce on public-key cryptography, authenticated encryption
+   */
+  export const crypto_box_NONCEBYTES: any;
+
+  /**
+   * Bytes of the authentication on public-key cryptography, authenticated encryption
+   */
+  export const crypto_box_MACBYTES: any;
+
+  /**
+   *
+   */
+  export const crypto_box_ZEROBYTES: any;
+
+  /**
+   *
+   */
+  export const crypto_box_SEALBYTES: any;
+
+  /**
+   * Randomly generates a secret key and a corresponding public key.
+   */
+  export function crypto_box_keypair(): Promise<any>;
+
+  /**
+   * Encrypts a message, with a recipient's public key, a sender's secret key and a nonce.
+   */
+  export function crypto_box_easy(
+    message: string,
+    nonce: string,
+    publicKey: string,
+    secretKey: string
+  ): Promise<any>;
+
+  /**
+   * Computes a shared secret key given a precalculated shared secret key.
+   */
+  export function crypto_box_easy_afternm(
+    message: string,
+    nonce: string,
+    k: string
+  ): Promise<any>;
+
+  /**
+   * Verifies and decrypts a ciphertext produced by crypto_box_easy().
+   * The nonce has to match the nonce used to encrypt and authenticate the message.
+   * Uses the public key of the sender that encrypted the message and the secret key
+   * of the recipient that is willing to verify and decrypt it.
+   */
+  export function crypto_box_open_easy(
+    cipher: string,
+    nonce: string,
+    publicKey: string,
+    secretKey: string
+  ): Promise<any>;
+
+  /**
+   * Computes a shared secret key given a precalculated shared secret key.
+   */
+  export function crypto_box_open_easy_afternm(
+    cipher: string,
+    nonce: string,
+    k: string
+  ): Promise<any>;
+
+  /**
+   * Computes a shared secret key given a public key pk and a secret key.
+   */
+  export function crypto_box_beforenm(
+    publicKey: string,
+    secretKey: string
+  ): Promise<any>;
+
+  /**
+   * The key pair can be deterministically derived from a single key seed.
+   */
+  export function crypto_scalarmult_base(nonce: string): Promise<any>;
+
+  //
+  // Public-key cryptography - Sealed boxes
+  //
+  /**
+   * Encrypts a message for a recipient's public key.
+   */
+  export function crypto_box_seal(
+    message: string,
+    publicKey: string
+  ): Promise<any>;
+
+  /**
+   * Decrypts the ciphertext using the key pair.
+   */
+  export function crypto_box_seal_open(
+    cipher: string,
+    publicKey: string,
+    secretKey: string
+  ): Promise<any>;
+
+  //
+  // Public-key cryptography - Public-key signatures
+  //
+  /**
+   * Bytes of public key on public-key cryptography, public-key signatures
+   */
+  export const crypto_sign_PUBLICKEYBYTES: any;
+
+  /**
+   * Bytes of secret key on public-key cryptography, public-key signatures
+   */
+  export const crypto_sign_SECRETKEYBYTES: any;
+
+  /**
+   * Bytes of single key seed on public-key cryptography, public-key signatures
+   */
+  export const crypto_sign_SEEDBYTES: any;
+
+  /**
+   * Bytes of the authentication on public-key cryptography, public-key signatures
+   */
+  export const crypto_sign_BYTES: any;
+
+  /**
+   * Signs the message using the secret key.
+   */
+  export function crypto_sign_detached(
+    msg: string,
+    secretKey: string
+  ): Promise<any>;
+
+  /**
+   * Verifies that sig is a valid signature for the message using the signer's public key.
+   */
+  export function crypto_sign_verify_detached(
+    sig: string,
+    msg: string,
+    publicKey: string
+  ): Promise<any>;
+
+  /**
+   * Randomly generates a secret key and a corresponding public key.
+   */
+  export function crypto_sign_keypair(): Promise<any>;
+
+  /**
+   * Get key pair derived from a single key seed.
+   */
+  export function crypto_sign_seed_keypair(seed: string): Promise<any>;
+
+  /**
+   * Extracts the seed from the secret key.
+   */
+  export function crypto_sign_ed25519_sk_to_seed(
+    secretKey: string
+  ): Promise<any>;
+
+  /**
+   * Converts an Ed25519 public key to an X25519 public key.
+   */
+  export function crypto_sign_ed25519_pk_to_curve25519(
+    publicKey: string
+  ): Promise<any>;
+
+  /**
+   * Converts an Ed25519 secret key to an X25519 secret key
+   */
+  export function crypto_sign_ed25519_sk_to_curve25519(
+    secretKey: string
+  ): Promise<any>;
+
+  /**
+   * Extracts the seed from the secret key sk.
+   */
+  export function crypto_sign_ed25519_sk_to_pk(secretKey: string): Promise<any>;
+
+  //
+  // Password hashing
+  //
+  /**
+   * Derives an key from a password and a salt whose fixed length is crypto_pwhash_SALTBYTES bytes.
+   */
+  export function crypto_pwhash(
+    keylen: number,
+    password: string,
+    salt: string,
+    opslimit: number,
+    memlimit: number,
+    algo: number
+  ): Promise<any>;
+
+  /**
+   * Bytes of salt on password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_SALTBYTES: any;
+
+  /**
+   * Baseline for computations to perform on password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_OPSLIMIT_MODERATE: any;
+
+  /**
+   * Minimum numbers of CPU cycles to compute a key on password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_OPSLIMIT_MIN: any;
+
+  /**
+   * Maximum numbers of CPU cycles to compute a key on password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_OPSLIMIT_MAX: any;
+
+  /**
+   * Baseline for memory on password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_MEMLIMIT_MODERATE: any;
+
+  /**
+   * Minimum memory allowed to compute a key on password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_MEMLIMIT_MIN: any;
+
+  /**
+   * Maximum memory allowed to compute a key on password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_MEMLIMIT_MAX: any;
+
+  /**
+   * Tthe currently recommended algorithm, which can change from one version of libsodium to another.
+   * On password hashing, the pwhash* API.
+   */
+  export const crypto_pwhash_ALG_DEFAULT: any;
+
+  /**
+   * Version 1.3 of the Argon2i algorithm.
+   */
+  export const crypto_pwhash_ALG_ARGON2I13: any;
+
+  /**
+   * Version 1.3 of the Argon2id algorithm, available since libsodium 1.0.13.
+   */
+  export const crypto_pwhash_ALG_ARGON2ID13: any;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module "react-native-sodium" {
-  export function sodium_version_string(): Promise<any>;
+  export function sodium_version_string(): Promise<string>;
 
   //
   // Generating random data
@@ -7,7 +7,7 @@ declare module "react-native-sodium" {
   /**
    * Returns an unpredictable value between 0 and 0xffffffff (included).
    */
-  export function randombytes_random(): Promise<any>;
+  export function randombytes_random(): Promise<number>;
 
   /**
    * Returns an unpredictable value between 0 and upper_bound (excluded).
@@ -15,26 +15,26 @@ declare module "react-native-sodium" {
    * the possible output values even when upper_bound is not a power of 2. Note that an
    * upper_bound < 2 leaves only a single element to be chosen, namely 0.
    */
-  export function randombytes_uniform(upper_bound: number): Promise<any>;
+  export function randombytes_uniform(upper_bound: number): Promise<number>;
 
   /**
    * Create a nonce
    */
-  export function randombytes_buf(size: number): Promise<any>;
+  export function randombytes_buf(size: number): Promise<string>;
 
   /**
    * This deallocates the global resources used by the pseudo-random number generator.
    * More specifically, when the /dev/urandom device is used, it closes the descriptor.
    * Explicitly calling this function is almost never required.
    */
-  export function randombytes_close(): Promise<any>;
+  export function randombytes_close(): Promise<number>;
 
   /**
    * Reseeds the pseudo-random number generator, if it supports this operation.
    * Calling this function is not required with the default generator, even after a fork() call,
    * unless the descriptor for /dev/urandom was closed using randombytes_close().
    */
-  export function randombytes_stir(): Promise<any>;
+  export function randombytes_stir(): Promise<number>;
 
   //
   // Secret-key cryptography - Authenticated encryption
@@ -42,23 +42,23 @@ declare module "react-native-sodium" {
   /**
    * Bytes of key on secret-key cryptography, authenticated encryption
    */
-  export const crypto_secretbox_KEYBYTES: any;
+  export const crypto_secretbox_KEYBYTES: number;
 
   /**
    * Bytes of nonce on secret-key cryptography, authenticated encryption
    */
-  export const crypto_secretbox_NONCEBYTES: any;
+  export const crypto_secretbox_NONCEBYTES: number;
 
   /**
    * Bytes of the authentication on secret-key cryptography, authenticated encryption
    */
-  export const crypto_secretbox_MACBYTES: any;
+  export const crypto_secretbox_MACBYTES: number;
 
   /**
    * Creates a random key. It is equivalent to calling randombytes_buf() but improves code
    * clarity and can prevent misuse by ensuring that the provided key length is always be correct.
    */
-  export function crypto_secretbox_keygen(): Promise<any>;
+  export function crypto_secretbox_keygen(): Promise<string>;
 
   /**
    * Encrypts a message, with a nonce and a key.
@@ -67,7 +67,7 @@ declare module "react-native-sodium" {
     message: string,
     nonce: string,
     key: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Verifies and decrypts a ciphertext produced by crypto_secretbox_easy().
@@ -77,7 +77,7 @@ declare module "react-native-sodium" {
     cipher: string,
     nonce: string,
     key: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   //
   // Secret-key cryptography - Authentication
@@ -85,26 +85,32 @@ declare module "react-native-sodium" {
   /**
    * Bytes of key on secret-key cryptography, authentication
    */
-  export const crypto_auth_KEYBYTES: any;
+  export const crypto_auth_KEYBYTES: number;
 
   /**
    * Bytes of the authentication on secret-key cryptography, authentication
    */
-  export const crypto_auth_BYTES: any;
+  export const crypto_auth_BYTES: number;
+
+  /**
+   * Creates a random key. It is equivalent to calling randombytes_buf() but improves code
+   * clarity and can prevent misuse by ensuring that the provided key length is always be correct.
+   */
+  export function crypto_auth_keygen(): Promise<string>;
 
   /**
    * Computes a tag for the message and the key.
    */
-  export function crypto_auth(inTag: string, key: string): Promise<any>;
+  export function crypto_auth(message: string, key: string): Promise<string>;
 
   /**
-   * Verifies that the tag stored at h is a valid tag for the message, and the key.
+   * Verifies that the tag is valid for the message and the key.
    */
   export function crypto_auth_verify(
-    h: string,
-    inTag: string,
+    tag: string,
+    message: string,
     key: string
-  ): Promise<any>;
+  ): Promise<number>;
 
   //
   // Public-key cryptography - Authenticated encryption
@@ -112,37 +118,37 @@ declare module "react-native-sodium" {
   /**
    * Bytes of public key on public-key cryptography, authenticated encryption
    */
-  export const crypto_box_PUBLICKEYBYTES: any;
+  export const crypto_box_PUBLICKEYBYTES: number;
 
   /**
    * Bytes of secret key on public-key cryptography, authenticated encryption
    */
-  export const crypto_box_SECRETKEYBYTES: any;
+  export const crypto_box_SECRETKEYBYTES: number;
 
   /**
    * Bytes of nonce on public-key cryptography, authenticated encryption
    */
-  export const crypto_box_NONCEBYTES: any;
+  export const crypto_box_NONCEBYTES: number;
 
   /**
    * Bytes of the authentication on public-key cryptography, authenticated encryption
    */
-  export const crypto_box_MACBYTES: any;
+  export const crypto_box_MACBYTES: number;
 
   /**
    *
    */
-  export const crypto_box_ZEROBYTES: any;
+  export const crypto_box_ZEROBYTES: number;
 
   /**
    *
    */
-  export const crypto_box_SEALBYTES: any;
+  export const crypto_box_SEALBYTES: number;
 
   /**
-   * Randomly generates a secret key and a corresponding public key.
+   * Randomly generates a secret key (sk) and a corresponding public key (pk).
    */
-  export function crypto_box_keypair(): Promise<any>;
+  export function crypto_box_keypair(): Promise<{ sk: string; pk: string }>;
 
   /**
    * Encrypts a message, with a recipient's public key, a sender's secret key and a nonce.
@@ -152,7 +158,7 @@ declare module "react-native-sodium" {
     nonce: string,
     publicKey: string,
     secretKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Computes a shared secret key given a precalculated shared secret key.
@@ -161,7 +167,7 @@ declare module "react-native-sodium" {
     message: string,
     nonce: string,
     k: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Verifies and decrypts a ciphertext produced by crypto_box_easy().
@@ -174,7 +180,7 @@ declare module "react-native-sodium" {
     nonce: string,
     publicKey: string,
     secretKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Computes a shared secret key given a precalculated shared secret key.
@@ -183,7 +189,7 @@ declare module "react-native-sodium" {
     cipher: string,
     nonce: string,
     k: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Computes a shared secret key given a public key pk and a secret key.
@@ -191,32 +197,33 @@ declare module "react-native-sodium" {
   export function crypto_box_beforenm(
     publicKey: string,
     secretKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * The key pair can be deterministically derived from a single key seed.
    */
-  export function crypto_scalarmult_base(nonce: string): Promise<any>;
+  export function crypto_scalarmult_base(secretKey: string): Promise<string>;
 
   //
   // Public-key cryptography - Sealed boxes
   //
   /**
-   * Encrypts a message for a recipient's public key.
+   * Encrypts a message for a recipient's public key. Only the recipient can decrypt
+   * these messages, using its private key and it cannot verify the identity of the sender.
    */
   export function crypto_box_seal(
     message: string,
     publicKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
-   * Decrypts the ciphertext using the key pair.
+   * Decrypts the ciphertext from crypto_box_seal, using the key pair.
    */
   export function crypto_box_seal_open(
     cipher: string,
     publicKey: string,
     secretKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   //
   // Public-key cryptography - Public-key signatures
@@ -224,22 +231,22 @@ declare module "react-native-sodium" {
   /**
    * Bytes of public key on public-key cryptography, public-key signatures
    */
-  export const crypto_sign_PUBLICKEYBYTES: any;
+  export const crypto_sign_PUBLICKEYBYTES: number;
 
   /**
    * Bytes of secret key on public-key cryptography, public-key signatures
    */
-  export const crypto_sign_SECRETKEYBYTES: any;
+  export const crypto_sign_SECRETKEYBYTES: number;
 
   /**
    * Bytes of single key seed on public-key cryptography, public-key signatures
    */
-  export const crypto_sign_SEEDBYTES: any;
+  export const crypto_sign_SEEDBYTES: number;
 
   /**
    * Bytes of the authentication on public-key cryptography, public-key signatures
    */
-  export const crypto_sign_BYTES: any;
+  export const crypto_sign_BYTES: number;
 
   /**
    * Signs the message using the secret key.
@@ -247,7 +254,7 @@ declare module "react-native-sodium" {
   export function crypto_sign_detached(
     msg: string,
     secretKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Verifies that sig is a valid signature for the message using the signer's public key.
@@ -256,43 +263,47 @@ declare module "react-native-sodium" {
     sig: string,
     msg: string,
     publicKey: string
-  ): Promise<any>;
+  ): Promise<boolean>;
 
   /**
    * Randomly generates a secret key and a corresponding public key.
    */
-  export function crypto_sign_keypair(): Promise<any>;
+  export function crypto_sign_keypair(): Promise<{ sk: string; pk: string }>;
 
   /**
    * Get key pair derived from a single key seed.
    */
-  export function crypto_sign_seed_keypair(seed: string): Promise<any>;
+  export function crypto_sign_seed_keypair(
+    seed: string
+  ): Promise<{ sk: string; pk: string }>;
 
   /**
    * Extracts the seed from the secret key.
    */
   export function crypto_sign_ed25519_sk_to_seed(
     secretKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Converts an Ed25519 public key to an X25519 public key.
    */
   export function crypto_sign_ed25519_pk_to_curve25519(
     publicKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Converts an Ed25519 secret key to an X25519 secret key
    */
   export function crypto_sign_ed25519_sk_to_curve25519(
     secretKey: string
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Extracts the seed from the secret key sk.
    */
-  export function crypto_sign_ed25519_sk_to_pk(secretKey: string): Promise<any>;
+  export function crypto_sign_ed25519_sk_to_pk(
+    secretKey: string
+  ): Promise<string>;
 
   //
   // Password hashing
@@ -307,56 +318,56 @@ declare module "react-native-sodium" {
     opslimit: number,
     memlimit: number,
     algo: number
-  ): Promise<any>;
+  ): Promise<string>;
 
   /**
    * Bytes of salt on password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_SALTBYTES: any;
+  export const crypto_pwhash_SALTBYTES: number;
 
   /**
    * Baseline for computations to perform on password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_OPSLIMIT_MODERATE: any;
+  export const crypto_pwhash_OPSLIMIT_MODERATE: number;
 
   /**
    * Minimum numbers of CPU cycles to compute a key on password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_OPSLIMIT_MIN: any;
+  export const crypto_pwhash_OPSLIMIT_MIN: number;
 
   /**
    * Maximum numbers of CPU cycles to compute a key on password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_OPSLIMIT_MAX: any;
+  export const crypto_pwhash_OPSLIMIT_MAX: number;
 
   /**
    * Baseline for memory on password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_MEMLIMIT_MODERATE: any;
+  export const crypto_pwhash_MEMLIMIT_MODERATE: number;
 
   /**
    * Minimum memory allowed to compute a key on password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_MEMLIMIT_MIN: any;
+  export const crypto_pwhash_MEMLIMIT_MIN: number;
 
   /**
    * Maximum memory allowed to compute a key on password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_MEMLIMIT_MAX: any;
+  export const crypto_pwhash_MEMLIMIT_MAX: number;
 
   /**
    * Tthe currently recommended algorithm, which can change from one version of libsodium to another.
    * On password hashing, the pwhash* API.
    */
-  export const crypto_pwhash_ALG_DEFAULT: any;
+  export const crypto_pwhash_ALG_DEFAULT: number;
 
   /**
    * Version 1.3 of the Argon2i algorithm.
    */
-  export const crypto_pwhash_ALG_ARGON2I13: any;
+  export const crypto_pwhash_ALG_ARGON2I13: number;
 
   /**
    * Version 1.3 of the Argon2id algorithm, available since libsodium 1.0.13.
    */
-  export const crypto_pwhash_ALG_ARGON2ID13: any;
+  export const crypto_pwhash_ALG_ARGON2ID13: number;
 }

--- a/ios/RCTSodium/RCTSodium.h
+++ b/ios/RCTSodium/RCTSodium.h
@@ -20,6 +20,8 @@
 - (void) crypto_secretbox_keygen:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_secretbox_easy:(NSString*)m n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_secretbox_open_easy:(NSString*)c n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+
+- (void) crypto_auth_keygen:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_auth:(NSString*)in k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_auth_verify:(NSString*)h in:(NSString*)in k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 

--- a/ios/RCTSodium/RCTSodium.h
+++ b/ios/RCTSodium/RCTSodium.h
@@ -17,6 +17,7 @@
 - (void) randombytes_close:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) randombytes_stir:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
+- (void) crypto_secretbox_keygen:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_secretbox_easy:(NSString*)m n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_secretbox_open_easy:(NSString*)c n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_auth:(NSString*)in k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;

--- a/ios/RCTSodium/RCTSodium.m
+++ b/ios/RCTSodium/RCTSodium.m
@@ -170,6 +170,13 @@ RCT_EXPORT_METHOD(crypto_secretbox_open_easy:(NSString*)c n:(NSString*)n k:(NSSt
 // ***************************************************************************
 // * Secret-key cryptography - authentication
 // ***************************************************************************
+RCT_EXPORT_METHOD(crypto_auth_keygen:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+  unsigned char key[crypto_auth_KEYBYTES];
+  crypto_auth_keygen(key)
+  resolve([[NSData dataWithBytesNoCopy:key length:sizeof(key) freeWhenDone:NO]  base64EncodedStringWithOptions:0]);
+}
+
 RCT_EXPORT_METHOD(crypto_auth:(NSString*)in k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
   unsigned char out[crypto_auth_BYTES];

--- a/ios/RCTSodium/RCTSodium.m
+++ b/ios/RCTSodium/RCTSodium.m
@@ -122,6 +122,17 @@ RCT_EXPORT_METHOD(randombytes_stir:(RCTPromiseResolveBlock)resolve reject:(__unu
 // *****************************************************************************
 // * Secret-key cryptography - authenticated encryption
 // *****************************************************************************
+RCT_EXPORT_METHOD(crypto_secretbox_keygen:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+{
+  unsigned char key[crypto_secretbox_KEYBYTES];
+  if ( crypto_secretbox_keygen(key) == 0) {
+    NSString *key64 = [[NSData dataWithBytesNoCopy:key length:sizeof(key) freeWhenDone:NO]  base64EncodedStringWithOptions:0];
+    if (!key64) reject(ESODIUM,ERR_FAILURE,nil); else resolve(@(key));
+  }
+  else
+    reject(ESODIUM,ERR_FAILURE,nil);
+}
+
 RCT_EXPORT_METHOD(crypto_secretbox_easy:(NSString*)m n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
   const NSData *dm = [[NSData alloc] initWithBase64EncodedString:m options:0];

--- a/ios/RCTSodium/RCTSodium.m
+++ b/ios/RCTSodium/RCTSodium.m
@@ -125,12 +125,9 @@ RCT_EXPORT_METHOD(randombytes_stir:(RCTPromiseResolveBlock)resolve reject:(__unu
 RCT_EXPORT_METHOD(crypto_secretbox_keygen:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
   unsigned char key[crypto_secretbox_KEYBYTES];
-  if ( crypto_secretbox_keygen(key) == 0) {
-    NSString *key64 = [[NSData dataWithBytesNoCopy:key length:sizeof(key) freeWhenDone:NO]  base64EncodedStringWithOptions:0];
-    if (!key64) reject(ESODIUM,ERR_FAILURE,nil); else resolve(@(key));
-  }
-  else
-    reject(ESODIUM,ERR_FAILURE,nil);
+  crypto_secretbox_keygen(key)
+  NSString *key64 = [[NSData dataWithBytesNoCopy:key length:sizeof(key) freeWhenDone:NO]  base64EncodedStringWithOptions:0];
+  if (!key64) reject(ESODIUM,ERR_FAILURE,nil); else resolve(@(key));
 }
 
 RCT_EXPORT_METHOD(crypto_secretbox_easy:(NSString*)m n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)

--- a/ios/RCTSodium/RCTSodium.m
+++ b/ios/RCTSodium/RCTSodium.m
@@ -126,8 +126,7 @@ RCT_EXPORT_METHOD(crypto_secretbox_keygen:(RCTPromiseResolveBlock)resolve reject
 {
   unsigned char key[crypto_secretbox_KEYBYTES];
   crypto_secretbox_keygen(key)
-  NSString *key64 = [[NSData dataWithBytesNoCopy:key length:sizeof(key) freeWhenDone:NO]  base64EncodedStringWithOptions:0];
-  if (!key64) reject(ESODIUM,ERR_FAILURE,nil); else resolve(@(key));
+  resolve([[NSData dataWithBytesNoCopy:key length:sizeof(key) freeWhenDone:NO]  base64EncodedStringWithOptions:0]);
 }
 
 RCT_EXPORT_METHOD(crypto_secretbox_easy:(NSString*)m n:(NSString*)n k:(NSString*)k resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
According to the docs the `crypto_secretbox_keygen` is equivalent to calling `randombytes_buf()` but improves code clarity and can prevent misuse by ensuring that the provided key length is always be correct.
Same thing for `crypto_auth_keygen`.

Also fix `secretbox` functions using `box` constants.

And add typescript declaration files, with proper types.

Tested on Android, but can't test on iOS.