### PR TITLE
base64/hex utils

### DIFF
--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -8,6 +8,22 @@ extern "C" {
 #endif
 
 /* *****************************************************************************
+ * Helpers
+ * *****************************************************************************
+ */
+
+// use only for copying values, returning values here from crypto won't work
+unsigned char* as_unsigned_char_array(JNIEnv *jenv, jbyteArray array) {
+    if (array == NULL) {
+        return NULL;
+    }
+    int len = (*jenv)->GetArrayLength (jenv, array);
+    unsigned char* buf = malloc(len);
+    (*jenv)->GetByteArrayRegion (jenv, array, 0, len, (jbyte*)(buf));
+    return buf;
+}
+
+/* *****************************************************************************
  * Sodium-specific functions
  * *****************************************************************************
  */
@@ -453,6 +469,85 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1sign_1ed25519_1s
   (*jenv)->ReleaseByteArrayElements(jenv, j_sk, (jbyte *) sk, 0);
   (*jenv)->ReleaseByteArrayElements(jenv, j_pk, (jbyte *) pk, 0);
   return (jint)result;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_base64_1variant_1ORIGINAL(JNIEnv *env, jclass clazz) {
+    return (jint)sodium_base64_VARIANT_ORIGINAL;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_base64_1variant_1VARIANT_1ORIGINAL_1NO_1PADDING(JNIEnv *env,
+                                                                                 jclass clazz) {
+    return (jint)sodium_base64_VARIANT_ORIGINAL_NO_PADDING;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_base64_1variant_1VARIANT_1URLSAFE(JNIEnv *env, jclass clazz) {
+    return (jint)sodium_base64_VARIANT_URLSAFE;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_base64_1variant_1VARIANT_1URLSAFE_1NO_1PADDING(JNIEnv *env,
+                                                                                jclass clazz) {
+    return (jint)sodium_base64_VARIANT_URLSAFE_NO_PADDING;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_sodium_1base642bin(JNIEnv *jenv, jclass clazz, jbyteArray j_bin,
+                                                    jint j_bin_maxlen, jbyteArray j_b64, jint j_b64_len,
+                                                    jbyteArray j_ignore, jintArray j_bin_len,
+                                                    jbyteArray j_b64_end, jint j_variant) {
+    unsigned char *bin = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_bin, 0);
+    unsigned char *b64 = as_unsigned_char_array(jenv, j_b64);
+    unsigned char *ignore = as_unsigned_char_array(jenv, j_ignore);
+
+    int result = sodium_base642bin(bin, j_bin_maxlen, b64, j_b64_len, ignore, j_bin_len, j_b64_end, j_variant);
+    (*jenv)->ReleaseByteArrayElements(jenv, j_bin, (jbyte *) bin, 0);
+    return (jint)result;
+}
+
+JNIEXPORT jchar JNICALL
+Java_org_libsodium_jni_SodiumJNI_sodium_1bin2hex(JNIEnv *jenv, jclass clazz, jbyteArray j_hex,
+                                                 jint j_hex_maxlen, jbyteArray j_bin, jint j_bin_len) {
+    unsigned char *hex = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_hex, 0);
+    unsigned char *bin = as_unsigned_char_array(jenv, j_bin);
+
+    int result = sodium_bin2hex(hex, j_hex_maxlen, bin, j_bin_len);
+    (*jenv)->ReleaseByteArrayElements(jenv, j_hex, (jbyte *) hex, 0);
+    return (jint)result;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_sodium_1hex2bin(JNIEnv *jenv, jclass clazz, jbyteArray j_bin,
+                                                 jint j_bin_maxlen, jbyteArray j_hex, jint j_hex_len,
+                                                 jbyteArray j_ignore, jintArray j_bin_len,
+                                                 jbyteArray j_hex_end) {
+    unsigned char *bin = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_bin, 0);
+    unsigned char *hex = as_unsigned_char_array(jenv, j_hex);
+    unsigned char *ignore = as_unsigned_char_array(jenv, j_ignore);
+
+    int result = sodium_hex2bin(bin, j_bin_maxlen, hex, j_hex_len, ignore,j_bin_len, j_hex_end);
+    (*jenv)->ReleaseByteArrayElements(jenv, j_bin, (jbyte *) bin, 0);
+    return (jint)result;
+}
+
+JNIEXPORT jchar JNICALL
+Java_org_libsodium_jni_SodiumJNI_sodium_1bin2base64(JNIEnv *jenv, jclass clazz, jbyteArray j_b64,
+                                                    jint j_b64_maxlen, jbyteArray j_bin, jint j_bin_len,
+                                                    jint j_variant) {
+    unsigned char *b64 = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_b64, 0);
+    unsigned char *bin = as_unsigned_char_array(jenv, j_bin);
+
+    int result = sodium_bin2base64(b64, j_b64_maxlen, bin, j_bin_len, j_variant);
+    (*jenv)->ReleaseByteArrayElements(jenv, j_b64, (jbyte *) b64, 0);
+    return (jint)result;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_sodium_1base64_1encoded_1len(JNIEnv *jenv, jclass clazz,
+                                                              jint j_bin_len, jint j_variant) {
+    return (jint) sodium_base64_encoded_len(j_bin_len, j_variant);
 }
 
 #ifdef __cplusplus

--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -1,4 +1,3 @@
-
 #include <jni.h>
 #include "sodium.h"
 
@@ -6,22 +5,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* *****************************************************************************
- * Helpers
- * *****************************************************************************
- */
-
-// use only for copying values, returning values here from crypto won't work
-unsigned char* as_unsigned_char_array(JNIEnv *jenv, jbyteArray array) {
-    if (array == NULL) {
-        return NULL;
-    }
-    int len = (*jenv)->GetArrayLength (jenv, array);
-    unsigned char* buf = malloc(len);
-    (*jenv)->GetByteArrayRegion (jenv, array, 0, len, (jbyte*)(buf));
-    return buf;
-}
 
 /* *****************************************************************************
  * Sodium-specific functions
@@ -89,12 +72,6 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1macby
 return (jint) crypto_secretbox_MACBYTES;
 }
 
-JNIEXPORT void JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
-  unsigned char *key = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_key, 0);
-  crypto_secretbox_keygen(key);
-  (*jenv)->ReleaseByteArrayElements(jenv, j_key, (jbyte *) key, 0);
-}
-
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1easy(JNIEnv *jenv, jclass jcls, jbyteArray j_c, jbyteArray j_m, jlong j_mlen, jbyteArray j_n, jbyteArray j_k) {
   unsigned char *c = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_c, 0);
   unsigned char *m = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_m, 0);
@@ -131,12 +108,6 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1bytes(JNIE
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1keybytes(JNIEnv *jenv, jclass jcls) {
   return (jint) crypto_auth_KEYBYTES;
-}
-
-JNIEXPORT void JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
-  unsigned char *key = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_key, 0);
-  crypto_auth_keygen(key);
-  (*jenv)->ReleaseByteArrayElements(jenv, j_key, (jbyte *) key, 0);
 }
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth(JNIEnv *jenv, jclass jcls, jbyteArray j_out, jbyteArray j_in, jlong j_inlen, jbyteArray j_k) {
@@ -178,14 +149,6 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1secretkeyby
  return  (jint)crypto_box_SECRETKEYBYTES;
 }
 
-JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1beforenmbytes(JNIEnv *jenv, jclass jcls) {
- return (jint) crypto_box_BEFORENMBYTES;
-}
-
-JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1seedbytes(JNIEnv *jenv, jclass jcls) {
- return (jint) crypto_box_SEEDBYTES;
-}
-
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1noncebytes(JNIEnv *jenv, jclass jcls) {
  return  (jint)crypto_box_NONCEBYTES;
 }
@@ -196,10 +159,6 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1macbytes(JN
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1zerobytes(JNIEnv *jenv, jclass jcls) {
  return (jint) crypto_box_ZEROBYTES;
-}
-
-JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1boxzerobytes(JNIEnv *jenv, jclass jcls) {
- return (jint) crypto_box_BOXZEROBYTES;
 }
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1sealbytes(JNIEnv *jenv, jclass jcls) {
@@ -306,10 +265,6 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1seal_1open(
   return (jint) result;
 }
 
-/* *****************************************************************************
- * Password hashing - The pwhash* API
- * *****************************************************************************
- */
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1pwhash(JNIEnv *jenv, jclass jcls, jbyteArray j_out, jlong j_olong, jbyteArray j_p, jlong j_plen, jbyteArray j_salt, jlong j_opslimit, jlong jmemlimit, jint j_algo) {
   const char *password = (const char *) (*jenv)->GetByteArrayElements(jenv, j_p, 0);
   unsigned char *salt = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_salt, 0);
@@ -471,6 +426,99 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1sign_1ed25519_1s
   return (jint)result;
 }
 
+// use only for copying values, returning values here from crypto won't work
+unsigned char* as_unsigned_char_array(JNIEnv *jenv, jbyteArray array) {
+    if (array == NULL) {
+        return NULL;
+    }
+    int len = (*jenv)->GetArrayLength (jenv, array);
+    unsigned char* buf = malloc(len);
+    (*jenv)->GetByteArrayRegion (jenv, array, 0, len, (jbyte*)(buf));
+    return buf;
+}
+
+JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1ietf_1encrypt(JNIEnv *jenv,
+                                                                                jclass clazz,
+                                                                                jbyteArray j_c,
+                                                                                jintArray  j_clen,
+                                                                                jbyteArray j_m,
+                                                                                jint j_mlen,
+                                                                                jbyteArray j_ad,
+                                                                                jint j_adlen,
+                                                                                jbyteArray j_nsec,
+                                                                                jbyteArray j_npub,
+                                                                                jbyteArray j_k) {
+
+    unsigned char *c = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_c, 0);
+    unsigned char *m = as_unsigned_char_array(jenv, j_m);
+    unsigned char *npub = as_unsigned_char_array(jenv, j_npub);
+    unsigned char *ad = as_unsigned_char_array(jenv, j_ad);
+    unsigned char *nsec = as_unsigned_char_array(jenv, j_nsec);
+    unsigned char *k = as_unsigned_char_array(jenv, j_k);
+
+    int result = crypto_aead_xchacha20poly1305_ietf_encrypt(c, j_clen, m, j_mlen, ad, j_adlen, nsec, npub, k);
+    (*jenv)->ReleaseByteArrayElements(jenv, j_c, (jbyte *) c, 0);
+    return (jint)result;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1ietf_1decrypt(JNIEnv *jenv,
+                                                                                jclass clazz,
+                                                                                jbyteArray j_m,
+                                                                                jintArray j_mlen_p,
+                                                                                jbyteArray j_nsec,
+                                                                                jbyteArray j_c,
+                                                                                jint j_clen,
+                                                                                jbyteArray j_ad,
+                                                                                jint j_adlen,
+                                                                                jbyteArray j_npub,
+                                                                                jbyteArray j_k) {
+    unsigned char *c = as_unsigned_char_array(jenv, j_c);
+    unsigned char *m = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_m, 0);
+    unsigned char *npub = as_unsigned_char_array(jenv, j_npub);
+    unsigned char *ad = as_unsigned_char_array(jenv, j_ad);
+    unsigned char *nsec = as_unsigned_char_array(jenv, j_nsec);
+    unsigned char *k = as_unsigned_char_array(jenv, j_k);
+
+    int result = crypto_aead_xchacha20poly1305_ietf_decrypt(m, j_mlen_p, nsec, c, j_clen, ad, j_adlen, npub, k);
+    (*jenv)->ReleaseByteArrayElements(jenv, j_m, (jbyte *) m, 0);
+    return (jint)result;
+}
+
+JNIEXPORT jchar JNICALL
+Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1ietf_1keygen(JNIEnv *jenv,
+                                                                               jclass clazz,
+                                                                               jbyteArray j_k) {
+  unsigned char *k = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_k, 0);
+  crypto_aead_xchacha20poly1305_ietf_keygen(k);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_k, (jbyte *) k, 0);
+  return k;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1chacha20poly1305_1IETF_1ABYTES(JNIEnv *env,
+                                                                              jclass clazz) {
+  return (jint) crypto_aead_chacha20poly1305_IETF_ABYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1IETF_1KEYBYTES(JNIEnv *env,
+                                                                                 jclass clazz) {
+  return (jint)crypto_aead_xchacha20poly1305_IETF_KEYBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1IETF_1NPUBBYTES(JNIEnv *env,
+                                                                                  jclass clazz) {
+  return (jint)crypto_aead_xchacha20poly1305_IETF_NPUBBYTES;
+}
+
+JNIEXPORT jint JNICALL
+Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1IETF_1NSECBYTES(JNIEnv *env,
+                                                                                  jclass clazz) {
+  return (jint)crypto_aead_xchacha20poly1305_IETF_NSECBYTES;
+}
+
 JNIEXPORT jint JNICALL
 Java_org_libsodium_jni_SodiumJNI_base64_1variant_1ORIGINAL(JNIEnv *env, jclass clazz) {
     return (jint)sodium_base64_VARIANT_ORIGINAL;
@@ -502,13 +550,15 @@ Java_org_libsodium_jni_SodiumJNI_sodium_1base642bin(JNIEnv *jenv, jclass clazz, 
     jint *len = (*jenv)->GetIntArrayElements(jenv, j_bin_len, 0);
     unsigned char *b64 = as_unsigned_char_array(jenv, j_b64);
     unsigned char *ignore = as_unsigned_char_array(jenv, j_ignore);
-    unsigned int len_res = 0;
+    void *memory = malloc(sizeof(int));
+    int *ptr = (int *)memory;
 
     int result = sodium_base642bin(bin, j_bin_maxlen, b64, j_b64_len, ignore,
-                                   &len_res, j_b64_end, j_variant);
+                                   ptr, j_b64_end, j_variant);
     (*jenv)->ReleaseByteArrayElements(jenv, j_bin, (jbyte *) bin, 0);
-    len[0] = len_res;
+    len[0] = *ptr;
     (*jenv)->ReleaseIntArrayElements(jenv, j_bin_len, len, 0);
+    free(memory);
     return (jint)result;
 }
 
@@ -532,12 +582,14 @@ Java_org_libsodium_jni_SodiumJNI_sodium_1hex2bin(JNIEnv *jenv, jclass clazz, jby
     jint *len = (*jenv)->GetIntArrayElements(jenv, j_bin_len, 0);
     unsigned char *hex = as_unsigned_char_array(jenv, j_hex);
     unsigned char *ignore = as_unsigned_char_array(jenv, j_ignore);
-    unsigned int len_res = 0;
+    void *memory = malloc(sizeof(int));
+    int *ptr = (int *)memory;
 
-    int result = sodium_hex2bin(bin, j_bin_maxlen, hex, j_hex_len, ignore, &len_res, j_hex_end);
+    int result = sodium_hex2bin(bin, j_bin_maxlen, hex, j_hex_len, ignore, ptr, j_hex_end);
     (*jenv)->ReleaseByteArrayElements(jenv, j_bin, (jbyte *) bin, 0);
-    len[0] = len_res;
+    len[0] = *ptr;
     (*jenv)->ReleaseIntArrayElements(jenv, j_bin_len, len, 0);
+    free(memory);
     return (jint)result;
 }
 

--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -7,6 +7,22 @@ extern "C" {
 #endif
 
 /* *****************************************************************************
+ * Helpers
+ * *****************************************************************************
+ */
+
+// use only for copying values, returning values here from crypto won't work
+unsigned char* as_unsigned_char_array(JNIEnv *jenv, jbyteArray array) {
+    if (array == NULL) {
+        return NULL;
+    }
+    int len = (*jenv)->GetArrayLength (jenv, array);
+    unsigned char* buf = malloc(len);
+    (*jenv)->GetByteArrayRegion (jenv, array, 0, len, (jbyte*)(buf));
+    return buf;
+}
+
+/* *****************************************************************************
  * Sodium-specific functions
  * *****************************************************************************
  */
@@ -72,6 +88,12 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1macby
 return (jint) crypto_secretbox_MACBYTES;
 }
 
+JNIEXPORT void JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
+  unsigned char *key = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_key, 0);
+  crypto_secretbox_keygen(key);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_key, (jbyte *) key, 0);
+}
+
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1secretbox_1easy(JNIEnv *jenv, jclass jcls, jbyteArray j_c, jbyteArray j_m, jlong j_mlen, jbyteArray j_n, jbyteArray j_k) {
   unsigned char *c = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_c, 0);
   unsigned char *m = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_m, 0);
@@ -108,6 +130,12 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1bytes(JNIE
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1keybytes(JNIEnv *jenv, jclass jcls) {
   return (jint) crypto_auth_KEYBYTES;
+}
+
+JNIEXPORT void JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth_1keygen(JNIEnv *jenv, jclass jcls, jbyteArray j_key) {
+  unsigned char *key = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_key, 0);
+  crypto_auth_keygen(key);
+  (*jenv)->ReleaseByteArrayElements(jenv, j_key, (jbyte *) key, 0);
 }
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1auth(JNIEnv *jenv, jclass jcls, jbyteArray j_out, jbyteArray j_in, jlong j_inlen, jbyteArray j_k) {
@@ -149,6 +177,14 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1secretkeyby
  return  (jint)crypto_box_SECRETKEYBYTES;
 }
 
+JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1beforenmbytes(JNIEnv *jenv, jclass jcls) {
+ return (jint) crypto_box_BEFORENMBYTES;
+}
+
+JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1seedbytes(JNIEnv *jenv, jclass jcls) {
+ return (jint) crypto_box_SEEDBYTES;
+}
+
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1noncebytes(JNIEnv *jenv, jclass jcls) {
  return  (jint)crypto_box_NONCEBYTES;
 }
@@ -159,6 +195,10 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1macbytes(JN
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1zerobytes(JNIEnv *jenv, jclass jcls) {
  return (jint) crypto_box_ZEROBYTES;
+}
+
+JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1boxzerobytes(JNIEnv *jenv, jclass jcls) {
+ return (jint) crypto_box_BOXZEROBYTES;
 }
 
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1sealbytes(JNIEnv *jenv, jclass jcls) {
@@ -265,6 +305,10 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1box_1seal_1open(
   return (jint) result;
 }
 
+/* *****************************************************************************
+ * Password hashing - The pwhash* API
+ * *****************************************************************************
+ */
 JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1pwhash(JNIEnv *jenv, jclass jcls, jbyteArray j_out, jlong j_olong, jbyteArray j_p, jlong j_plen, jbyteArray j_salt, jlong j_opslimit, jlong jmemlimit, jint j_algo) {
   const char *password = (const char *) (*jenv)->GetByteArrayElements(jenv, j_p, 0);
   unsigned char *salt = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_salt, 0);
@@ -424,99 +468,6 @@ JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1sign_1ed25519_1s
   (*jenv)->ReleaseByteArrayElements(jenv, j_sk, (jbyte *) sk, 0);
   (*jenv)->ReleaseByteArrayElements(jenv, j_pk, (jbyte *) pk, 0);
   return (jint)result;
-}
-
-// use only for copying values, returning values here from crypto won't work
-unsigned char* as_unsigned_char_array(JNIEnv *jenv, jbyteArray array) {
-    if (array == NULL) {
-        return NULL;
-    }
-    int len = (*jenv)->GetArrayLength (jenv, array);
-    unsigned char* buf = malloc(len);
-    (*jenv)->GetByteArrayRegion (jenv, array, 0, len, (jbyte*)(buf));
-    return buf;
-}
-
-JNIEXPORT jint JNICALL Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1ietf_1encrypt(JNIEnv *jenv,
-                                                                                jclass clazz,
-                                                                                jbyteArray j_c,
-                                                                                jintArray  j_clen,
-                                                                                jbyteArray j_m,
-                                                                                jint j_mlen,
-                                                                                jbyteArray j_ad,
-                                                                                jint j_adlen,
-                                                                                jbyteArray j_nsec,
-                                                                                jbyteArray j_npub,
-                                                                                jbyteArray j_k) {
-
-    unsigned char *c = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_c, 0);
-    unsigned char *m = as_unsigned_char_array(jenv, j_m);
-    unsigned char *npub = as_unsigned_char_array(jenv, j_npub);
-    unsigned char *ad = as_unsigned_char_array(jenv, j_ad);
-    unsigned char *nsec = as_unsigned_char_array(jenv, j_nsec);
-    unsigned char *k = as_unsigned_char_array(jenv, j_k);
-
-    int result = crypto_aead_xchacha20poly1305_ietf_encrypt(c, j_clen, m, j_mlen, ad, j_adlen, nsec, npub, k);
-    (*jenv)->ReleaseByteArrayElements(jenv, j_c, (jbyte *) c, 0);
-    return (jint)result;
-}
-
-JNIEXPORT jint JNICALL
-Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1ietf_1decrypt(JNIEnv *jenv,
-                                                                                jclass clazz,
-                                                                                jbyteArray j_m,
-                                                                                jintArray j_mlen_p,
-                                                                                jbyteArray j_nsec,
-                                                                                jbyteArray j_c,
-                                                                                jint j_clen,
-                                                                                jbyteArray j_ad,
-                                                                                jint j_adlen,
-                                                                                jbyteArray j_npub,
-                                                                                jbyteArray j_k) {
-    unsigned char *c = as_unsigned_char_array(jenv, j_c);
-    unsigned char *m = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_m, 0);
-    unsigned char *npub = as_unsigned_char_array(jenv, j_npub);
-    unsigned char *ad = as_unsigned_char_array(jenv, j_ad);
-    unsigned char *nsec = as_unsigned_char_array(jenv, j_nsec);
-    unsigned char *k = as_unsigned_char_array(jenv, j_k);
-
-    int result = crypto_aead_xchacha20poly1305_ietf_decrypt(m, j_mlen_p, nsec, c, j_clen, ad, j_adlen, npub, k);
-    (*jenv)->ReleaseByteArrayElements(jenv, j_m, (jbyte *) m, 0);
-    return (jint)result;
-}
-
-JNIEXPORT jchar JNICALL
-Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1ietf_1keygen(JNIEnv *jenv,
-                                                                               jclass clazz,
-                                                                               jbyteArray j_k) {
-  unsigned char *k = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_k, 0);
-  crypto_aead_xchacha20poly1305_ietf_keygen(k);
-  (*jenv)->ReleaseByteArrayElements(jenv, j_k, (jbyte *) k, 0);
-  return k;
-}
-
-JNIEXPORT jint JNICALL
-Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1chacha20poly1305_1IETF_1ABYTES(JNIEnv *env,
-                                                                              jclass clazz) {
-  return (jint) crypto_aead_chacha20poly1305_IETF_ABYTES;
-}
-
-JNIEXPORT jint JNICALL
-Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1IETF_1KEYBYTES(JNIEnv *env,
-                                                                                 jclass clazz) {
-  return (jint)crypto_aead_xchacha20poly1305_IETF_KEYBYTES;
-}
-
-JNIEXPORT jint JNICALL
-Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1IETF_1NPUBBYTES(JNIEnv *env,
-                                                                                  jclass clazz) {
-  return (jint)crypto_aead_xchacha20poly1305_IETF_NPUBBYTES;
-}
-
-JNIEXPORT jint JNICALL
-Java_org_libsodium_jni_SodiumJNI_crypto_1aead_1xchacha20poly1305_1IETF_1NSECBYTES(JNIEnv *env,
-                                                                                  jclass clazz) {
-  return (jint)crypto_aead_xchacha20poly1305_IETF_NSECBYTES;
 }
 
 JNIEXPORT jint JNICALL

--- a/android/src/main/cpp/sodium-jni.c
+++ b/android/src/main/cpp/sodium-jni.c
@@ -499,11 +499,16 @@ Java_org_libsodium_jni_SodiumJNI_sodium_1base642bin(JNIEnv *jenv, jclass clazz, 
                                                     jbyteArray j_ignore, jintArray j_bin_len,
                                                     jbyteArray j_b64_end, jint j_variant) {
     unsigned char *bin = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_bin, 0);
+    jint *len = (*jenv)->GetIntArrayElements(jenv, j_bin_len, 0);
     unsigned char *b64 = as_unsigned_char_array(jenv, j_b64);
     unsigned char *ignore = as_unsigned_char_array(jenv, j_ignore);
+    unsigned int len_res = 0;
 
-    int result = sodium_base642bin(bin, j_bin_maxlen, b64, j_b64_len, ignore, j_bin_len, j_b64_end, j_variant);
+    int result = sodium_base642bin(bin, j_bin_maxlen, b64, j_b64_len, ignore,
+                                   &len_res, j_b64_end, j_variant);
     (*jenv)->ReleaseByteArrayElements(jenv, j_bin, (jbyte *) bin, 0);
+    len[0] = len_res;
+    (*jenv)->ReleaseIntArrayElements(jenv, j_bin_len, len, 0);
     return (jint)result;
 }
 
@@ -524,11 +529,15 @@ Java_org_libsodium_jni_SodiumJNI_sodium_1hex2bin(JNIEnv *jenv, jclass clazz, jby
                                                  jbyteArray j_ignore, jintArray j_bin_len,
                                                  jbyteArray j_hex_end) {
     unsigned char *bin = (unsigned char *) (*jenv)->GetByteArrayElements(jenv, j_bin, 0);
+    jint *len = (*jenv)->GetIntArrayElements(jenv, j_bin_len, 0);
     unsigned char *hex = as_unsigned_char_array(jenv, j_hex);
     unsigned char *ignore = as_unsigned_char_array(jenv, j_ignore);
+    unsigned int len_res = 0;
 
-    int result = sodium_hex2bin(bin, j_bin_maxlen, hex, j_hex_len, ignore,j_bin_len, j_hex_end);
+    int result = sodium_hex2bin(bin, j_bin_maxlen, hex, j_hex_len, ignore, &len_res, j_hex_end);
     (*jenv)->ReleaseByteArrayElements(jenv, j_bin, (jbyte *) bin, 0);
+    len[0] = len_res;
+    (*jenv)->ReleaseIntArrayElements(jenv, j_bin_len, len, 0);
     return (jint)result;
 }
 

--- a/android/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/android/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -76,8 +76,8 @@ public class SodiumJNI {
   public final static native int base64_variant_VARIANT_URLSAFE_NO_PADDING();
 
   public final static native char sodium_bin2base64(byte[] b64, final int b64_maxlen, final byte[] bin, final int bin_len, final int variant);
-  public final static native int sodium_base642bin(final byte[] bin, int bin_maxlen, final byte[] b64, final int b64_len, final byte[] ignore, final int[] bin_len, final byte[] b64_end, final int variant);
+  public final static native int sodium_base642bin(final byte[] bin, int bin_maxlen, final byte[] b64, final int b64_len, final byte[] ignore, int[] bin_len, final byte[] b64_end, final int variant);
   public final static native char sodium_bin2hex(byte[] hex, int hex_maxlen, byte[] bin, final int bin_len);
-  public final static native int sodium_hex2bin(byte[] bin, final int bin_maxlen, final byte[] hex, final int hex_len, final byte[] ignore, final int[] bin_len, final byte[] hex_end);
+  public final static native int sodium_hex2bin(byte[] bin, final int bin_maxlen, final byte[] hex, final int hex_len, final byte[] ignore, int[] bin_len, final byte[] hex_end);
   public final static native int sodium_base64_encoded_len(final int bin_len, final int variant);
 }

--- a/android/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/android/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -69,4 +69,15 @@ public class SodiumJNI {
   public final static native int crypto_sign_ed25519_pk_to_curve25519(byte[] curve25519_pk, final byte[] ed25519_pk);
   public final static native int crypto_sign_ed25519_sk_to_curve25519(byte[] curve25519_sk, final byte[] ed25519_sk);
   public final static native int crypto_sign_ed25519_sk_to_pk(byte[] sk, byte[] pk);
+
+  public final static native int base64_variant_ORIGINAL();
+  public final static native int base64_variant_VARIANT_ORIGINAL_NO_PADDING();
+  public final static native int base64_variant_VARIANT_URLSAFE();
+  public final static native int base64_variant_VARIANT_URLSAFE_NO_PADDING();
+
+  public final static native char sodium_bin2base64(byte[] b64, final int b64_maxlen, final byte[] bin, final int bin_len, final int variant);
+  public final static native int sodium_base642bin(final byte[] bin, int bin_maxlen, final byte[] b64, final int b64_len, final byte[] ignore, final int[] bin_len, final byte[] b64_end, final int variant);
+  public final static native char sodium_bin2hex(byte[] hex, int hex_maxlen, byte[] bin, final int bin_len);
+  public final static native int sodium_hex2bin(byte[] bin, final int bin_maxlen, final byte[] hex, final int hex_len, final byte[] ignore, final int[] bin_len, final byte[] hex_end);
+  public final static native int sodium_base64_encoded_len(final int bin_len, final int variant);
 }

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -665,4 +665,127 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
       p.reject(ESODIUM, ERR_FAILURE, t);
     }
   }
+
+  // ***************************************************************************
+  // * Utils
+  // ***************************************************************************
+
+  @ReactMethod
+  public void to_base64(final String message, final int variant, final Promise p) {
+    byte[] m = message.getBytes(StandardCharsets.UTF_8);
+    String result = this.binToBase64(m, variant);
+    if (result == null) {
+      p.reject(ESODIUM,ERR_FAILURE);
+    } else {
+      p.resolve(result);
+    }
+  }
+
+  @ReactMethod
+  public void from_base64(final String cipher, final int variant, final Promise p) {
+    byte[] result = this.base64ToBin(cipher, variant);
+    if (result == null) {
+      p.reject(ESODIUM,ERR_FAILURE);
+    } else {
+      p.resolve(new String(result, StandardCharsets.UTF_8));
+    }
+  }
+
+  @ReactMethod
+  public void to_hex(final String message, final Promise p) {
+    byte[] m = message.getBytes(StandardCharsets.UTF_8);
+    String result = this.binToHex(m);
+    if (result == null) {
+      p.reject(ESODIUM,ERR_FAILURE);
+    } else {
+      p.resolve(result);
+    }
+  }
+
+  @ReactMethod
+  public void from_hex(final String cipher, final Promise p) {
+    byte[] result = this.hexToBin(cipher);
+    if (result == null) {
+      p.reject(ESODIUM,ERR_FAILURE);
+    } else {
+      p.resolve(new String(result, StandardCharsets.UTF_8));
+    }
+  }
+
+  private String binToBase64(final byte[] data, final int variant) {
+    try {
+      if (data.length <= 0 || variant == 0)
+        return null;
+      else {
+        int encoded_len = Sodium.sodium_base64_encoded_len(data.length, variant);
+        byte[] encoded = new byte[encoded_len];
+        Sodium.sodium_bin2base64(encoded, encoded_len, data, data.length, variant);
+        return new String(encoded, StandardCharsets.UTF_8);
+      }
+    }
+    catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private byte[] base64ToBin(String cipher, final int variant) {
+    try {
+      byte[] c = cipher.getBytes(StandardCharsets.UTF_8);
+
+      if (c.length <= 0 || variant == 0)
+        return null;
+
+      else {
+        int blen = c.length;
+        byte[] decoded = new byte[blen];
+        int[] decoded_len = new int[1];
+        int result = Sodium.sodium_base642bin(decoded, blen, c, c.length, null, decoded_len, null, variant);
+        if (result != 0)
+          return null;
+        else
+          return decoded;
+      }
+    }
+    catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private String binToHex(final byte[] data) {
+    try {
+      if (data.length <= 0)
+        return null;
+
+      else {
+        int encoded_len = data.length * 2 + 1;
+        byte[] encoded = new byte[encoded_len];
+        Sodium.sodium_bin2hex(encoded, encoded_len, data, data.length);
+        return new String(encoded, StandardCharsets.UTF_8);
+      }
+    } catch (Throwable t) {
+      return null;
+    }
+  }
+
+  private byte[] hexToBin(String cipher) {
+    try {
+      byte[] c = cipher.getBytes(StandardCharsets.UTF_8);
+
+      if (c.length <= 0)
+        return null;
+
+      else {
+        int blen = c.length;
+        byte[] decoded = new byte[blen];
+        int[] decoded_len = new int[1];
+        int result = Sodium.sodium_hex2bin(decoded, blen, c, c.length, null, decoded_len, null);
+        if (result != 0)
+          return null;
+        else
+          return decoded;
+      }
+    } catch (Throwable t) {
+      return null;
+    }
+  }
 }

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -743,7 +743,7 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
         if (result != 0)
           return null;
         else
-          return decoded;
+          return Arrays.copyOfRange(decoded, 0, decoded_len[0]);
       }
     }
     catch (Throwable t) {
@@ -782,7 +782,7 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
         if (result != 0)
           return null;
         else
-          return decoded;
+          return Arrays.copyOfRange(decoded, 0, decoded_len[0]);
       }
     } catch (Throwable t) {
       return null;

--- a/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
+++ b/android/src/main/java/org/libsodium/rn/RCTSodiumModule.java
@@ -728,7 +728,7 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
     }
   }
 
-  private byte[] base64ToBin(String cipher, final int variant) {
+    private byte[] base64ToBin(String cipher, final int variant) {
     try {
       byte[] c = cipher.getBytes(StandardCharsets.UTF_8);
 
@@ -742,8 +742,19 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
         int result = Sodium.sodium_base642bin(decoded, blen, c, c.length, null, decoded_len, null, variant);
         if (result != 0)
           return null;
-        else
-          return decoded;
+        else {
+          int lastGoodCharIndex = c.length -1;
+          for(int i=0; i< decoded.length; i++)
+          {
+            int bint = Byte.valueOf(decoded[i]).intValue();
+
+            if (bint != 0)
+            {
+              lastGoodCharIndex = i;
+            }
+          }
+          return Arrays.copyOfRange(decoded, 0, lastGoodCharIndex + 1);
+        }
       }
     }
     catch (Throwable t) {
@@ -775,7 +786,7 @@ public class RCTSodiumModule extends ReactContextBaseJavaModule {
         return null;
 
       else {
-        int blen = c.length;
+        int blen = c.length / 2;
         byte[] decoded = new byte[blen];
         int[] decoded_len = new int[1];
         int result = Sodium.sodium_hex2bin(decoded, blen, c, c.length, null, decoded_len, null);

--- a/index.d.ts
+++ b/index.d.ts
@@ -320,6 +320,18 @@ declare module "react-native-sodium" {
     algo: number
   ): Promise<string>;
 
+
+  //
+  // Utils
+  //
+  export function to_base64(message: string, variant: number): Promise<string>;
+
+  export function from_base64(cipher: string, variant: number): Promise<string>;
+
+  export function to_hex(message: string): Promise<string>;
+
+  export function from_hex(cipher: string): Promise<string>;
+
   /**
    * Bytes of salt on password hashing, the pwhash* API.
    */
@@ -370,4 +382,12 @@ declare module "react-native-sodium" {
    * Version 1.3 of the Argon2id algorithm, available since libsodium 1.0.13.
    */
   export const crypto_pwhash_ALG_ARGON2ID13: number;
+
+  export const base64_variant_ORIGINAL: number;
+  
+  export const base64_variant_VARIANT_ORIGINAL_NO_PADDING: number;
+
+  export const base64_variant_VARIANT_URLSAFE: number;
+
+  export const base64_variant_VARIANT_URLSAFE_NO_PADDING: number;
 }

--- a/ios/RCTSodium/RCTSodium.h
+++ b/ios/RCTSodium/RCTSodium.h
@@ -44,4 +44,10 @@
 - (void) crypto_box_seal:(NSString*)m pk:(NSString*)pk resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void) crypto_box_seal_open:(NSString*)c pk:(NSString*)pk sk:(NSString*)sk resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
+- (void) to_base64:(NSString*)message variant:(NSNumber*)variant resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void) from_base64:(NSString*)cipher variant:(NSNumber*)variant resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+
+- (void) to_hex:(NSString*)message resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+- (void) from_hex:(NSString*)cipher resolve: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+
 @end

--- a/ios/RCTSodium/RCTSodium.m
+++ b/ios/RCTSodium/RCTSodium.m
@@ -494,7 +494,7 @@ RCT_EXPORT_METHOD(to_base64:(NSString*)message variant:(NSNumber * _Nonnull)vari
 {
     NSData *m = [message dataUsingEncoding:NSUTF8StringEncoding];
 
-    if (m != nil || !variant) {
+    if (m == nil || !variant) {
         reject(ESODIUM, ERR_FAILURE, nil);
     } else {
         NSString *encodedString = [self binToBase64:m variant:variant];


### PR DESCRIPTION
We implemented helpers that are similar to `libsodium.js` helpers. Eventually, those should be probably used instead of platform-specific base64 tools for input/output.