### PR TITLE
Fix Android Build by removing jniLibs.srcDirs from android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,11 +43,6 @@ android {
             path "CMakeLists.txt"
         }
     }
-    sourceSets {
-        main {
-            jniLibs.srcDirs = ['./lib']
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
 I'm not 100% sure if this is something that affects everyone and should be merged into the actual repo or if it is due to some other libraries we are using, so I'd be cautious before you merge it.