### PR TITLE
Use header_mappings_dir to fix header imports 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 29
+    buildToolsVersion "29.0.2"
     defaultConfig {
-        minSdkVersion 16
-        compileSdkVersion 28
-        targetSdkVersion 28
+        minSdkVersion 21
+        compileSdkVersion 29
+        targetSdkVersion 29
         versionCode 1
         versionName "0.1"
         compileOptions {

--- a/react-native-sodium.podspec
+++ b/react-native-sodium.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/lyubo/react-native-sodium.git", :tag => "v#{s.version}" }
   s.source_files  = ["ios/**/*.{h,m}","libsodium/libsodium-ios/**/*.{h,m}"]
+  s.header_mappings_dir = 'libsodium/libsodium-ios/include'
 
   s.vendored_libraries = 'libsodium/libsodium-ios/lib/libsodium.a'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/Headers/Public/#{s.name}/**'}


### PR DESCRIPTION
This fixes my issue in #44 

This Podspec configuration maps paths starting from the given base directory. Otherwise, the header paths are flattened. I believe it is specific to "use_frameworks!" but have not validated.