### PR TITLE
Use framework import (`<` instead of `"`) for React

### DIFF
--- a/ios/RCTSodium/RCTSodium.m
+++ b/ios/RCTSodium/RCTSodium.m
@@ -5,8 +5,8 @@
 //  Created by Lyubomir Ivanov on 9/25/16.
 //  Copyright © 2016 Lyubomir Ivanov. All rights reserved.
 //
-#import "RCTBridgeModule.h"
-#import "RCTUtils.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTUtils.h>
 #import "sodium.h"
 
 #import "RCTSodium.h"


### PR DESCRIPTION
Fixes a these build errors:

```
	CompileC /Users/mrousavy/Projects/Steakwallet/app/ios/build/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/react-native-sodium.build/Objects-normal/x86_64/RCTSodium.o /Users/mrousavy/Projects/Steakwallet/app/node_modules/react-native-sodium/ios/RCTSodium/RCTSodium.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'react-native-sodium' from project 'Pods')
(2 failures)

❌  /Users/mrousavy/Projects/Steakwallet/app/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:431:1: duplicate interface definition for class 'RCTBundleManager'

@interface RCTBundleManager : NSObject
           ^



❌  /Users/mrousavy/Projects/Steakwallet/app/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:437:18: property has a previous declaration

@property NSURL *bundleURL;
           ^



❌  /Users/mrousavy/Projects/Steakwallet/app/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:445:1: duplicate interface definition for class 'RCTViewRegistry'

@interface RCTViewRegistry : NSObject
                 ^



❌  /Users/mrousavy/Projects/Steakwallet/app/ios/Pods/Headers/Public/React-Core/React/RCTBridgeModule.h:462:1: duplicate interface definition for class 'RCTCallableJSModules'

@interface RCTCallableJSModules : NSObject
```